### PR TITLE
Ensure correct ID usage and file placement

### DIFF
--- a/Disconnection.py
+++ b/Disconnection.py
@@ -290,62 +290,48 @@ dataEQCimport = {
 }
 
 if __name__ == "__main__":
-    args: list[str] = []
+    args = sys.argv
 
-    for i,arg in enumerate(sys.argv):
-        args.append(arg)
-
-    if len(args) == 2:
-        init_case(args[1], dataEQCexport,EQCexportPath) # type: ignore
-        init_case(args[1], dataEPCexport,EPCexportPath) # type: ignore
-        init_case(args[1], dataPSNSexport, PSandNSexportPath) # type: ignore
-        init_case(args[1], dataRTRPexport, RTandRPexportPath) # type: ignore
-
-        init_case(args[1], dataPSNSimport, PSandNSimportPath) # type: ignore
-        init_case(args[1], dataEPCimport, EPCimportPath) # type: ignore
-        init_case(args[1], dataRTRPimport, RTandRPimportPath) # type: ignore
-        init_case(args[1], dataEQCimport, EQCimportPath) # type: ignore
-
-        os.mkdir(f'APM files/{args[1]}/Exports Results')
-        os.mkdir(f'APM files/{args[1]}/Imports Results')
-
-        #Create ManagedBy File
-        dataCsv = {
-            'Account ID': [],
-            'Managed by': []
-        }
-
-        # Create a DataFrame from the data
-        dfCsv = pd.DataFrame(dataCsv)
-        # Specify the file name and path
-        file_pathCsv = f'APM files/{args[1]}/{args[1]} UpdateManagedBy.csv'
-        # Write the DataFrame to and Excel file
-        dfCsv.to_csv(file_pathCsv, index=False)
-        #print(f"ManagedBy.csv file has been created.")
-
-    elif len(args) == 3:
-        dataEQCexport['Hotel ID'] = [f'{args[2]}']
-        dataEPCexport['Hotel ID'] = [f'{args[2]}']
-        dataPSNSexport['Hotel ID'] = [f'{args[2]}']
-        dataRTRPexport['Hotel ID'] = [f'{args[2]}']
-        dataPSNSimport['Hotel ID'] = [f'{args[2]}']
-        dataEPCimport['Hotel ID'] = [f'{args[2]}']
-        dataRTRPimport['Hotel ID'] = [f'{args[2]}']
-        dataEQCimport['Hotel ID'] = [f'{args[2]}']
-
-        init_case(args[1], dataEQCexport,EQCexportPath) # type: ignore
-        init_case(args[1], dataEPCexport,EPCexportPath) # type: ignore
-        init_case(args[1], dataPSNSexport, PSandNSexportPath) # type: ignore
-        init_case(args[1], dataRTRPexport, RTandRPexportPath) # type: ignore
-
-        init_case(args[1], dataPSNSimport, PSandNSimportPath) # type: ignore
-        init_case(args[1], dataEPCimport, EPCimportPath) # type: ignore
-        init_case(args[1], dataRTRPimport, RTandRPimportPath) # type: ignore
-        init_case(args[1], dataEQCimport, EQCimportPath) # type: ignore
-
-        os.mkdir(f'APM files/{args[1]}/Exports Results')
-        os.mkdir(f'APM files/{args[1]}/Imports Results')
-
+    if len(args) == 3:
+        case_id, account_id, hotel_id = args[1], args[2], ""
+    elif len(args) == 4:
+        case_id, account_id, hotel_id = args[1], args[2], args[3]
     else:
         print('Does not met arguments requirements, directory not created.')
+        sys.exit()
+
+    for data in (
+        dataEQCexport,
+        dataEPCexport,
+        dataPSNSexport,
+        dataRTRPexport,
+        dataPSNSimport,
+        dataEPCimport,
+        dataRTRPimport,
+        dataEQCimport,
+    ):
+        if 'Hotel ID' in data:
+            data['Hotel ID'] = [hotel_id]
+    for data in (dataPSNSimport, dataEPCimport, dataRTRPimport, dataEQCimport):
+        data['SF ID'] = [case_id]
+
+    init_case(case_id, dataEQCexport, EQCexportPath)  # type: ignore
+    init_case(case_id, dataEPCexport, EPCexportPath)  # type: ignore
+    init_case(case_id, dataPSNSexport, PSandNSexportPath)  # type: ignore
+    init_case(case_id, dataRTRPexport, RTandRPexportPath)  # type: ignore
+
+    init_case(case_id, dataPSNSimport, PSandNSimportPath)  # type: ignore
+    init_case(case_id, dataEPCimport, EPCimportPath)  # type: ignore
+    init_case(case_id, dataRTRPimport, RTandRPimportPath)  # type: ignore
+    init_case(case_id, dataEQCimport, EQCimportPath)  # type: ignore
+
+    os.mkdir(f'APM files/{case_id}/Exports Results')
+    os.mkdir(f'APM files/{case_id}/Imports Results')
+
+    dataCsv = [
+        {'Account ID': hotel_id, 'Managed by': account_id}
+    ]
+    dfCsv = pd.DataFrame(dataCsv)
+    file_pathCsv = f'APM files/{case_id}/{case_id} UpdateManagedBy.csv'
+    dfCsv.to_csv(file_pathCsv, index=False)
 

--- a/Onboarding.py
+++ b/Onboarding.py
@@ -5,47 +5,34 @@ from tools.case_initializer import init_case
 
 remove_stop_selling_file_path = 'IMPORT Stop Sell Removal.xlsx'
 
-def onboarding():
-    args = []
-    
-    for i,arg in enumerate(sys.argv):
-        args.append(arg)
 
-    if len(args) == 2:
-        data_frame = {
-            'Hotel ID':[''],
-            'SF ID': [''],
-            'Stop Sell Property':['No'],
-            'Action Type':['Update']
-        }
-        init_case(args[1], data_frame, remove_stop_selling_file_path) # type: ignore
-        os.mkdir(f'APM files/{args[1]}/Imports Results')
-        
-        #Create ManagedBy File
-        data_csv = {
-            'Account ID': [],
-            'Managed by': []
-        }
+def onboarding() -> None:
+    args = sys.argv
 
-        # Create a DataFrame from the data
-        df_csv = pd.DataFrame(data_csv)
-        # Specify the file name and path
-        file_path_csv = f'APM files/{args[1]}/{args[1]} UpdateManagedBy.csv'
-        # Write the DataFrame to and Excel file
-        df_csv.to_csv(file_path_csv, index=False)
-        #print(f"ManagedBy.csv file has been created.")
-        
-    elif len(args) == 3:
-        data_frame = {
-            'Hotel ID':[f'{args[2]}'],
-            'Stop Sell Property':['No'],
-            'Action Type':['Update']
-        }
-        init_case(args[1], data_frame, remove_stop_selling_file_path) # type: ignore
-        os.mkdir(f'APM files/{args[1]}/Imports Results')
-    
+    if len(args) == 3:
+        case_id, account_id, hotel_id = args[1], args[2], ""
+    elif len(args) == 4:
+        case_id, account_id, hotel_id = args[1], args[2], args[3]
     else:
         print('Does not met arguments requirements, directory not created.')
+        return
+
+    data_frame = {
+        'Hotel ID': [hotel_id],
+        'SF ID': [case_id],
+        'Stop Sell Property': ['No'],
+        'Action Type': ['Update']
+    }
+    init_case(case_id, data_frame, remove_stop_selling_file_path)  # type: ignore
+    os.mkdir(f'APM files/{case_id}/Imports Results')
+
+    data_csv = [
+        {'Account ID': hotel_id, 'Managed by': account_id}
+    ]
+    df_csv = pd.DataFrame(data_csv)
+    file_path_csv = f'APM files/{case_id}/{case_id} UpdateManagedBy.csv'
+    df_csv.to_csv(file_path_csv, index=False)
+
 
 if __name__ == "__main__":
     onboarding()


### PR DESCRIPTION
## Summary
- Place generated files directly in the case folder and keep Exports/Imports Results empty
- Distinguish SF Case ID from Account ID when populating templates and managed-by CSVs
- Accept SF Account ID for CLI scripts and fill UpdateManagedBy with hotel IDs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68957150491c8331aa3cdc87c1dc3235